### PR TITLE
Windowsで発生するバグを修正

### DIFF
--- a/openssl/Dockerfile
+++ b/openssl/Dockerfile
@@ -69,6 +69,9 @@ RUN chown openssl:openssl /home/openssl/init.sh
 USER openssl
 WORKDIR /home/openssl
 
+# Replace Win linefeeds with the Linux ones 
+RUN sed -i 's/\r$//g' /home/openssl/init.sh 
+
 # init script
 RUN echo '. /home/openssl/init.sh' >> ~/.bashrc
 

--- a/openssl/init.sh
+++ b/openssl/init.sh
@@ -3,8 +3,14 @@
 trap "exit 0" SIGTERM SIGINT
 
 export PATH="/opt/openssl/bin:$PATH"
-export LD_LIBRARY_PATH="/opt/openssl/lib"
-export PKG_CONFIG_PATH="/opt/openssl/lib/pkgconfig"
+
+if [ -e "/opt/openssl/lib" ]; then
+	export LD_LIBRARY_PATH="/opt/openssl/lib"
+	export PKG_CONFIG_PATH="/opt/openssl/lib/pkgconfig"
+elif [ -e "/opt/openssl/lib64" ]; then # Path for 64 bit host 
+	export LD_LIBRARY_PATH="/opt/openssl/lib64"
+	export PKG_CONFIG_PATH="/opt/openssl/lib64/pkgconfig"
+fi
 
 openssl version
 


### PR DESCRIPTION
# Windowsで発生するバグを修正

## 再現環境
- ホストマシン：Windows11 (x64_86アーキテクチャ)
- コンテナ：WSL2 バックエンドDocker Desktop

## 不具合概要

1. Dockerfileに改行コードを変換する処理を追加
	- init.shの改行コードがWindows式(CRLF)のため常にLinux式(LF)になるように変更
	- WSL2 バックエンドDocker Desktopでdocker buildした際にエラーとなったため
2. init.sh内のパスを64bit端末に対応
	- 64bit端末でdocker runした際に、libではなくlib64にてディレクトリが作成されたため。

## 不具合詳細

### 1の不具合

> \# 改行コードがWindows用なのでinit.shファイルの読み込みで落ちてしまう
> PS D:\booktls-docker\openssl> docker container start -i booktls-openssl

### 2の不具合

> \# docker run時のエラーメッセージ
> PS D:\booktls-docker\openssl> docker run -it --name booktls-openssl booktls-openssl
> \+ trap 'exit 0' SIGTERM SIGINT
> \+ export PATH=/opt/openssl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
> \+ PATH=/opt/openssl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
> \+ export LD_LIBRARY_PATH=/opt/openssl/lib
> \+ LD_LIBRARY_PATH=/opt/openssl/lib
> \+ export PKG_CONFIG_PATH=/opt/openssl/lib/pkgconfig
> \+ PKG_CONFIG_PATH=/opt/openssl/lib/pkgconfig
> \+ openssl version
> openssl: /lib/x86_64-linux-gnu/libcrypto.so.3: version `OPENSSL_3.0.9' not found (required by openssl)